### PR TITLE
Consistently use connection vs conn

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ struct NewUser<'a> {
     favorite_color: Option<&'a str>,
 }
 
-fn create_user(conn: &Connection, name: &str, favorite_color: Option<&str>)
+fn create_user(connection: &Connection, name: &str, favorite_color: Option<&str>)
   -> DbResult<User>
 {
     let new_user = NewUser {
@@ -150,7 +150,7 @@ struct NewUser<'a>(
     Option<&'a str>,
 )
 
-fn create_user(conn: &Connection, name: &str, favorite_color: Option<&str>)
+fn create_user(connection: &Connection, name: &str, favorite_color: Option<&str>)
   -> DbResult<User>
 {
     let new_user = NewUser(name, favorite_color);
@@ -168,12 +168,12 @@ function which creates a query that you'll later pass to the `Connection`.
 Here's a simple example.
 
 ```rust
-fn change_users_name(conn: &Connection, target: i32, new_name: &str) -> DbResult<User> {
+fn change_users_name(connection: &Connection, target: i32, new_name: &str) -> DbResult<User> {
     use yaqb::query_builder::update;
     use users::dsl::*;
 
     let command = update(users.filter(id.eq(target))).set(name.eq(new_name));
-    conn.query_one(&command)
+    connection.query_one(&command)
         .map(|r| r.unwrap())
 }
 ```
@@ -199,10 +199,10 @@ changeset! {
     }
 }
 
-fn save_user(conn: &Connection, user: &mut User) -> DbResult<()> {
+fn save_user(connection: &Connection, user: &mut User) -> DbResult<()> {
     let command = update(users::table.filter(users::id.eq(user.id)))
         .set(user);
-    let updated_user = try!(conn.query_one(&command)).unwrap();
+    let updated_user = try!(connection.query_one(&command)).unwrap();
     *user = updated_user;
     Ok(())
 }
@@ -219,12 +219,12 @@ Delete works very similarly to `update`, but does not support returning a
 record.
 
 ```rust
-fn delete_user(conn: &Connection, user: User) -> DbResult<()> {
+fn delete_user(connection: &Connection, user: User) -> DbResult<()> {
     use yaqb::query_builder::delete;
     use users::dsl::*;
 
     let command = delete(users.filter(id.eq(user.id)));
-    let deleted_rows = try!(conn.execute_returning_count(&command));
+    let deleted_rows = try!(connection.execute_returning_count(&command));
     debug_assert!(deleted_rows == 1);
     Ok(())
 }


### PR DESCRIPTION
Some of the code examples had the argument named as conn but were using
connection