### PR TITLE
Add DbResult to default export

### DIFF
--- a/yaqb/src/lib.rs
+++ b/yaqb/src/lib.rs
@@ -26,8 +26,9 @@ pub mod helper_types {
 mod macros;
 
 pub use connection::{Connection, Cursor};
-pub use expression::{Expression, SelectableExpression, BoxableExpression};
+pub use db_result::{DbResult};
 pub use expression::expression_methods::*;
+pub use expression::{Expression, SelectableExpression, BoxableExpression};
 pub use query_dsl::*;
 pub use query_source::{QuerySource, Queriable, Table, Column, JoinTo};
 pub use result::{TransactionError, TransactionResult, ConnectionError, ConnectionResult};


### PR DESCRIPTION
DbResult is used in many functions as the return type when interacting
with yaqb.