### PR TITLE
Avoid duplicate `.env` files

### DIFF
--- a/yaqb/src/expression/extensions/interval_dsl.rs
+++ b/yaqb/src/expression/extensions/interval_dsl.rs
@@ -122,7 +122,10 @@ mod tests {
     macro_rules! test_fn {
         ($tpe:ty, $test_name:ident, $units:ident) => {
             fn $test_name(val: $tpe) -> bool {
-                dotenv::dotenv().ok();
+                let dotenv_path = ::std::env::current_dir()
+                    .and_then(|a| Ok(a.join("../.env"))).unwrap();
+                dotenv::from_path(dotenv_path.as_path()).ok();
+
                 let connection_url = ::std::env::var("DATABASE_URL").ok()
                     .expect("DATABASE_URL must be set in order to run tests");
                 let connection = Connection::establish(&connection_url).unwrap();

--- a/yaqb_tests/tests/schema.rs
+++ b/yaqb_tests/tests/schema.rs
@@ -167,7 +167,9 @@ pub fn connection() -> Connection {
 }
 
 pub fn connection_without_transaction() -> Connection {
-    dotenv::dotenv().ok();
+    let dotenv_path = ::std::env::current_dir()
+        .and_then(|a| Ok(a.join("../.env"))).unwrap();
+    dotenv::from_path(dotenv_path.as_path()).ok();
     let connection_url = ::std::env::var("DATABASE_URL").ok()
         .expect("DATABASE_URL must be set in order to run tests");
     Connection::establish(&connection_url).unwrap()


### PR DESCRIPTION
`dotenv::dotenv()` searches for the `.env` file in `std::env::current_dir()`, which resolves to the respective sub-project directories in this repo. To avoid using multiple `.env` files to run the whole project's tests, tell dotenv to look at the root of the repo.