### PR TITLE
Don't build yaqb twice in bin/test

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,3 @@
 #!/bin/sh
-(cd yaqb && cargo build && cargo test) &&
+(cd yaqb && cargo test) &&
   (cd yaqb_tests && cargo test)


### PR DESCRIPTION
`cargo test` ends up building yaqb, so there's no reason (that I know of) to build it beforehand as well.