### PR TITLE
Implement `IS NULL` and `IS NOT NULL`

### DIFF
--- a/yaqb/src/expression/expression_methods/global_expression_methods.rs
+++ b/yaqb/src/expression/expression_methods/global_expression_methods.rs
@@ -16,6 +16,14 @@ pub trait ExpressionMethods: Expression + Sized {
         NotEq::new(self, other.as_expression())
     }
 
+    fn is_null(self) -> IsNull<Self> {
+       IsNull::new(self)
+    }
+
+    fn is_not_null(self) -> IsNotNull<Self> {
+       IsNotNull::new(self)
+    }
+
     fn gt<T: AsExpression<Self::SqlType>>(self, other: T) -> Gt<Self, T::Expression> {
         Gt::new(self, other.as_expression())
     }

--- a/yaqb/src/expression/predicates.rs
+++ b/yaqb/src/expression/predicates.rs
@@ -47,6 +47,50 @@ macro_rules! infix_predicate {
     }
 }
 
+#[macro_export]
+macro_rules! postfix_predicate {
+    ($name:ident, $operator:expr) => {
+        postfix_predicate!($name, $operator, $crate::types::Bool);
+    };
+
+    ($name:ident, $operator:expr, $return_type:ty) => {
+        #[derive(Debug, Clone, Copy)]
+        pub struct $name<T> {
+            expr: T,
+        }
+
+        impl<T> $name<T> {
+            pub fn new(expr: T) -> Self {
+                $name {
+                    expr: expr,
+                }
+            }
+        }
+
+        impl<T> $crate::expression::Expression for $name<T> where
+            T: $crate::expression::Expression,
+        {
+            type SqlType = $return_type;
+
+            fn to_sql(&self, out: &mut $crate::query_builder::QueryBuilder) -> $crate::query_builder::BuildQueryResult {
+                try!(self.expr.to_sql(out));
+                out.push_sql($operator);
+                Ok(())
+            }
+        }
+
+        impl<T, QS> $crate::expression::SelectableExpression<QS> for $name<T> where
+            T: $crate::expression::SelectableExpression<QS>,
+        {
+        }
+
+        impl<T> $crate::expression::NonAggregate for $name<T> where
+            T: $crate::expression::NonAggregate,
+        {
+        }
+    }
+}
+
 infix_predicate!(And, " AND ");
 infix_predicate!(Between, " BETWEEN ");
 infix_predicate!(Eq, " = ");
@@ -59,6 +103,9 @@ infix_predicate!(NotBetween, " NOT BETWEEN ");
 infix_predicate!(NotEq, " != ");
 infix_predicate!(NotLike, " NOT LIKE ");
 infix_predicate!(Or, " OR ");
+
+postfix_predicate!(IsNull, " IS NULL");
+postfix_predicate!(IsNotNull, " IS NOT NULL");
 
 use query_source::Column;
 use query_builder::*;

--- a/yaqb_tests/tests/filter.rs
+++ b/yaqb_tests/tests/filter.rs
@@ -50,6 +50,40 @@ fn filter_by_equality_on_nullable_columns() {
 }
 
 #[test]
+fn filter_by_is_not_null_on_nullable_columns() {
+    use schema::users::dsl::*;
+
+    let connection = connection();
+    setup_users_table(&connection);
+    let data = vec![
+        NewUser::new("Derek", Some("red")),
+        NewUser::new("Gordon", None),
+    ];
+    connection.insert_returning_count(&users, &data).unwrap();
+
+    let derek = User::with_hair_color(1, "Derek", "red");
+    let source = users.filter(hair_color.is_not_null());
+    assert_eq!(vec![derek], source.load(&connection).unwrap().collect::<Vec<_>>());
+}
+
+#[test]
+fn filter_by_is_null_on_nullable_columns() {
+    use schema::users::dsl::*;
+
+    let connection = connection();
+    setup_users_table(&connection);
+    let data = vec![
+        NewUser::new("Derek", Some("red")),
+        NewUser::new("Gordon", None),
+    ];
+    connection.insert_returning_count(&users, &data).unwrap();
+
+    let gordon = User::new(2, "Gordon");
+    let source = users.filter(hair_color.is_null());
+    assert_eq!(vec![gordon], source.load(&connection).unwrap().collect::<Vec<_>>());
+}
+
+#[test]
 fn filter_after_joining() {
     use schema::users::name;
 


### PR DESCRIPTION
It is currently possible to call `is_null()` and `is_not_null()` on
columns that are non-nullable. This seems wasteful, but it's not
technically invalid SQL. I tried using yaqb to do this and it behaves as
expected.

If desired, a future change could constrain this further.